### PR TITLE
Feature/spawn with shell

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -659,7 +659,8 @@ Common.verifyConfs = function(appConfs) {
      * If command is like pm2 start "python xx.py --ok"
      * Then automatically start the script with bash -c and set a name eq to command
      */
-    if (app.script && app.script.indexOf(' ') > -1 && app.script === path.basename(app.script)) {
+    if (false && app.script && app.script.indexOf(' ') > -1 && app.script === path.basename(app.script)) {
+      console.log('Assuming command needs bash', app.script, app.name);
       var _script = app.script;
       if (require('shelljs').which('bash'))
         app.script = 'bash';

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -144,21 +144,25 @@ Common.prepareAppConf = function(opts, app) {
   cwd && (cwd[0] != '/') && (cwd = path.resolve(process.cwd(), cwd));
   cwd = cwd || opts.cwd;
 
-  // Full path script resolution
-  app.pm_exec_path = path.resolve(cwd, app.script);
+  if(app.exec_interpreter === 'none'){
+    app.pm_exec_path = app.script;
+  } else {
+    // Full path script resolution
+    app.pm_exec_path = path.resolve(cwd, app.script);
 
-  // If script does not exist after resolution
-  if (!fs.existsSync(app.pm_exec_path)) {
-    var ckd;
-    // Try resolve command available in $PATH
-    if ((ckd = require('shelljs').which(app.script))) {
-      if (typeof(ckd) !== 'string')
-        ckd = ckd.toString();
-      app.pm_exec_path = ckd;
+    // If script does not exist after resolution
+    if (!fs.existsSync(app.pm_exec_path)) {
+      var ckd;
+      // Try resolve command available in $PATH
+      if ((ckd = require('shelljs').which(app.script))) {
+        if (typeof(ckd) !== 'string')
+          ckd = ckd.toString();
+        app.pm_exec_path = ckd;
+      }
+      else
+        // Throw critical error
+        return new Error('script not found : ' + app.pm_exec_path);
     }
-    else
-      // Throw critical error
-      return new Error('script not found : ' + app.pm_exec_path);
   }
 
   /**
@@ -657,22 +661,11 @@ Common.verifyConfs = function(appConfs) {
 
     /**
      * If command is like pm2 start "python xx.py --ok"
-     * Then automatically start the script with bash -c and set a name eq to command
+     * Then automatically treat is as though it is a shell command
      */
-    if (false && app.script && app.script.indexOf(' ') > -1 && app.script === path.basename(app.script)) {
-      console.log('Assuming command needs bash', app.script, app.name);
-      var _script = app.script;
-      if (require('shelljs').which('bash'))
-        app.script = 'bash';
-      else if (require('shelljs').which('sh'))
-        app.script = 'sh';
-      else
-        throw new Error('bash and sh not available in $PATH')
-
-      app.args = ['-c', _script];
-      if (!app.name) {
-        app.name = _script
-      }
+    if (!app.exec_interpreter && app.script && app.script.indexOf(' ') > -1 && app.script === path.basename(app.script)) {
+      console.log('Assuming command needs a shell. script:', app.script, 'name:', app.name);
+      app.exec_interpreter = 'none'
     }
 
     /**

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -105,6 +105,7 @@ module.exports = function ForkMode(God) {
         }
         if(interpreter === 'none'){
             options.shell = true;
+            options.detached = false;
         }
         if (pm2_env.uid) {
           options.uid = pm2_env.uid

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -60,7 +60,8 @@ module.exports = function ForkMode(God) {
         args.push(pm2_env.pm_exec_path);
     }
     else {
-      command = '"' + pm2_env.pm_exec_path + '"';
+      var quoted = '"' + pm2_env.pm_exec_path + '"';
+      command = quoted.replace(/\\/g, '/'); // spawn needs fwd slash even on windows
     }
 
     if (pm2_env.args) {

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -61,7 +61,6 @@ module.exports = function ForkMode(God) {
     }
     else {
       command = pm2_env.pm_exec_path;
-      args = [ ];
     }
 
     if (pm2_env.args) {
@@ -100,7 +99,9 @@ module.exports = function ForkMode(God) {
         } else {
           options.windowsHide = true;
         }
-
+        if(interpreter === 'none'){
+            options.shell = true;
+        }
         if (pm2_env.uid) {
           options.uid = pm2_env.uid
         }

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -92,13 +92,16 @@ module.exports = function ForkMode(God) {
           env      : pm2_env,
           detached : true,
           cwd      : pm2_env.pm_cwd || process.cwd(),
-          stdio    : ['pipe', 'pipe', 'pipe', 'ipc'] //Same as fork() in node core
+          stdio    : ['pipe', 'pipe', 'pipe'] //Same as fork() in node core
         }
 
         if (typeof(pm2_env.windowsHide) === "boolean") {
           options.windowsHide = pm2_env.windowsHide;
         } else {
           options.windowsHide = true;
+        }
+        if(interpreter === 'node'){
+            options.stdio.push('ipc');
         }
         if(interpreter === 'none'){
             options.shell = true;

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -60,8 +60,9 @@ module.exports = function ForkMode(God) {
         args.push(pm2_env.pm_exec_path);
     }
     else {
-      var quoted = '"' + pm2_env.pm_exec_path + '"';
-      command = quoted.replace(/\\/g, '/'); // spawn needs fwd slash even on windows
+      var quoted = pm2_env.pm_exec_path;
+      console.log('pm2_env:', pm2_env);
+      command = quoted.replace(/\\/g, '\\\\'); // double up backslashes for the shell
     }
 
     if (pm2_env.args) {

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -60,7 +60,7 @@ module.exports = function ForkMode(God) {
         args.push(pm2_env.pm_exec_path);
     }
     else {
-      command = '"' + pm2_env.pm_exec_path '"';
+      command = '"' + pm2_env.pm_exec_path + '"';
     }
 
     if (pm2_env.args) {

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -60,7 +60,7 @@ module.exports = function ForkMode(God) {
         args.push(pm2_env.pm_exec_path);
     }
     else {
-      command = pm2_env.pm_exec_path;
+      command = '"' + pm2_env.pm_exec_path '"';
     }
 
     if (pm2_env.args) {

--- a/test/e2e/cli/start-app.sh
+++ b/test/e2e/cli/start-app.sh
@@ -10,9 +10,9 @@ cd $file_path/start-app
 #
 $pm2 delete all
 
-$pm2 start "node -e 'setTimeout(function() { }, 100000); console.log(process.env.TEST)'" -l test.log --merge-logs
-should 'should have started command' 'online' 1
-should 'should have not been restarted' 'restart_time: 0' 1
+$pm2 start "node -e 'setTimeout(function() { }, 100000); console.log(process.env.TEST)'" -l test.log --merge-logs --name node-test
+should 'should have started command from commandline' 'online' 1
+should 'should have not been restarted from commandline' 'restart_time: 0' 1
 
 cat test.log | grep "undefined" &> /dev/null
 spec "should have printed undefined env var"
@@ -20,8 +20,8 @@ spec "should have printed undefined env var"
 TEST='ok' $pm2 restart 0 --update-env
 cat test.log | grep "ok" &> /dev/null
 
-should 'should have started command' 'online' 1
-should 'should have not been restarted' 'restart_time: 1' 1
+should 'should have started command by id' 'online' 1
+should 'should have not been restarted by id' 'restart_time: 1' 1
 spec "should have printed undefined env var"
 
 #
@@ -30,7 +30,7 @@ spec "should have printed undefined env var"
 $pm2 delete all
 
 $pm2 start ecosystem.config.js
-should 'should have started command' 'online' 1
-should 'should have not been restarted' 'restart_time: 0' 1
+should 'should have started command from config' 'online' 1
+should 'should have not been restarted from config' 'restart_time: 0' 1
 cat test-conf.log | grep "test_val" 2> /dev/null
-spec "should have printed the test_val"
+spec "should have printed the test_val from config"


### PR DESCRIPTION
Use shell when spawning scripts where interpreter is 'none'.

This is a placeholder PR for now to see if the idea has merit and, if so, if we want to
apply this to `interpreter: 'none'` (which might break some existing users)
or create a new `interpreter: 'shell'` which will make the change opt-in.


<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->